### PR TITLE
Corrige ToUpper e nome catálogo

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ namespace NomeCompleto
            Console.Write("Digite seu sobrenome: ");
            sobrenome = Console.ReadLine();
            nomeCompleto = $"{nome} {sobrenome}";
-           nomeCatalogo = $"{sobrenome.ToUpper} {nome}";
+           nomeCatalogo = $"{sobrenome.ToUpper()}, {nome}";
            Console.WriteLine($"Nome completo: {nomeCompleto}");
            Console.WriteLine($"Nome catalogo: {nomeCatalogo}");
            


### PR DESCRIPTION
sobrenome.ToUpper estava sem o ()
Por via de regra, funções ou métodos sempre possuem o () (abre e fecha parênteses).